### PR TITLE
add Dependabot and dependency-submission workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,78 @@
+version: 2
+updates:
+  # Root workspace — Angular workspace config, dev tooling, and shared deps
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"        # 30 min after dependency-submission workflow (03:00 UTC)
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      angular:
+        patterns:
+          - "@angular/*"
+          - "@angular-devkit/*"
+          - "@angular-eslint/*"
+      sunbird:
+        patterns:
+          - "@project-sunbird/*"
+      karma-testing:
+        patterns:
+          - "karma*"
+          - "jasmine*"
+          - "@types/jasmine*"
+          - "@types/jasminewd2"
+      types:
+        patterns:
+          - "@types/*"
+
+  # Library package — the publishable Angular library (projects/sunbird-pdf-player)
+  - package-ecosystem: "npm"
+    directory: "/projects/sunbird-pdf-player"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      sunbird:
+        patterns:
+          - "@project-sunbird/*"
+
+  # Web component build — standalone ES module distribution
+  - package-ecosystem: "npm"
+    directory: "/web-component"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # Keep GitHub Actions workflow action versions updated
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"
+      timezone: "UTC"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,67 @@
+name: Dependency Submission
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'          # 03:00 UTC every Monday — runs before Dependabot (03:30)
+  push:
+    branches: [master]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'projects/sunbird-pdf-player/package.json'
+      - 'projects/sunbird-pdf-player/package-lock.json'
+      - 'web-component/package.json'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'projects/sunbird-pdf-player/package.json'
+      - 'projects/sunbird-pdf-player/package-lock.json'
+      - 'web-component/package.json'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  submit-npm-root:
+    name: Submit npm (root)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - uses: advanced-security/npm-dependency-submission-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  submit-npm-library:
+    name: Submit npm (projects/sunbird-pdf-player)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - uses: advanced-security/npm-dependency-submission-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          directory: ./projects/sunbird-pdf-player
+
+  submit-npm-web-component:
+    name: Submit npm (web-component)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      # No lock file in web-component/ — generate one without installing node_modules
+      - run: npm install --package-lock-only
+        working-directory: web-component
+      - uses: advanced-security/npm-dependency-submission-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          directory: ./web-component


### PR DESCRIPTION
## Summary                                             

  - Enables Dependabot to automatically open weekly PRs for outdated npm dependencies across all three package roots (root workspace, `projects/sunbird-pdf-player`, and              
  `web-component`) and for GitHub Actions versions.
  - Adds a `dependency-submission` workflow that populates the GitHub Dependency Graph for each npm workspace so GitHub's security advisories and Dependabot alerts have full         
  visibility into the dependency tree.                                                                                                                                                
  - Schedules dependency submission at 03:00 UTC (before Dependabot fires at 03:30) so the graph is always fresh when Dependabot evaluates updates.
                                                                                                                                                                                      
  ## Changes                                             
                                                                                                                                                                                      
  - Add `.github/dependabot.yml` with four update blocks: root npm, `projects/sunbird-pdf-player` npm, `web-component` npm, and GitHub Actions — each on a Monday 03:30 UTC schedule  
  with grouped PRs for Angular, Sunbird, Karma/Jasmine, and `@types/*` packages.
  - Add `.github/workflows/dependency-submission.yml` with three parallel jobs that submit the npm dependency snapshot for root, library, and web-component workspaces using          
  `advanced-security/npm-dependency-submission-action@v1`; the web-component job generates a lock file on-the-fly since none is committed.                                            
  ## How to Test
                                                                                                                                                                                      
  1. Merge this PR into `master`.                        
  2. Navigate to the repo's **Insights → Dependency graph** tab — all three npm workspaces and GitHub Actions dependencies should appear within a few minutes of the workflow's first 
  run.                                                                                                                                                                               
  3. On the following Monday at ~03:30 UTC, check **Pull requests** for Dependabot PRs labelled `dependencies`; they should be grouped per the configured patterns (e.g. all          
  `@angular/*` packages in one PR).                                                                                                                                         
  4. Alternatively, trigger the workflow manually: **Actions → Dependency Submission → Run workflow** and confirm all three jobs complete successfully.                               
                                                                                                                                                       
  ## Checklist                                                                                                                                                                        
                                                         
  - [ ] Tests added or updated                                                                                                                                                        
  - [ ] Documentation updated (if public API or behavior changed)                                                                                                                     
  - [ ] No breaking changes — or breaking changes noted with `!` in title and explained in Summary
  - [ ] Reviewed my own diff before requesting review